### PR TITLE
adds oci-hooks settings info for 1.15.x

### DIFF
--- a/content/en/os/1.15.x/api/settings/oci-hooks/_index.markdown
+++ b/content/en/os/1.15.x/api/settings/oci-hooks/_index.markdown
@@ -1,0 +1,10 @@
++++
+title="oci-hooks"
+type="docs"
+toc_hide=true
+description="Settings related host-provided OCI Hooks (`settings.oci-hooks.*`)."
++++
+
+Enable/disable OCI hooks provided by the host.
+
+{{< settings >}}

--- a/data/settings/1.15.x/oci-hooks.toml
+++ b/data/settings/1.15.x/oci-hooks.toml
@@ -1,0 +1,17 @@
+[[docs.ref.log4j-hotpatch-enabled]]
+deprecated = true
+accepted_values = [
+    "`true`",
+    "`false`"
+]
+description = """
+The log4j hotpatch functionality is no longer included in Bottlerocket as of v1.15.0.
+The setting still exists for backwards compatibility.
+
+If set to `true`, it prints the following message to the system logs:
+
+```
+The setting "oci-hooks.log4j-hotpatch-enabled" has no effect. It will be removed in future versions of Bottlerocket.
+```
+
+"""


### PR DESCRIPTION
**Issue number:**

Closes # n/a

**Description of changes:**
- Adds docs for settings 1.15.x oci-hooks (see bottlerocket-os/bottlerocket#3399)

**Terms of contribution:**

By submitting this pull request, I confirm that my contribution is made under
the terms of the licenses outlined in the LICENSE-SUMMARY file.
